### PR TITLE
feat: upgrade quarkus and project dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Manually create the database for local testing (with initialization file) ...
 podman run -d --name pg-library-shop -p 5432:5432 \
     -e POSTGRES_USER=quarkus -e POSTGRES_PASSWORD=quarkus -e POSTGRES_DATABASE=quarkus \
     -v $PWD/src/main/database:/docker-entrypoint-initdb.d:ro,z \
-    docker.io/library/postgres:14
+    docker.io/library/postgres:17
 ```
 
 ## Creating a native executable
@@ -66,7 +66,7 @@ If you want to learn more about building native executables, please consult http
 To create the container image review the file [Containerfile.jvm](./src/main/docker/Containerfile.jvm)
 
 ```Containerfile
-FROM registry.access.redhat.com/ubi9/openjdk-17-runtime:1.17-1
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.21-1
 
 ENV LANGUAGE='en_US:en'
 
@@ -121,7 +121,7 @@ podman run --rm -it -e DATABASE_HOST=alumno -p 8080:8080 rha/library-shop-docker
 ### Create a Container image for the native executable
 
 ```Containerfile
-FROM registry.access.redhat.com/ubi9/ubi-micro:9.3-6
+FROM registry.access.redhat.com/ubi9/ubi-micro:9.5-1733126338
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \
@@ -183,13 +183,28 @@ curl -s http://localhost:8080/library/ | jq
 ## More Quarkus: Related Guides
 
 - REST resources for Hibernate ORM with Panache ([guide](https://quarkus.io/guides/rest-data-panache)): Generate Jakarta REST resources for your Hibernate Panache entities and repositories
+- SmallRye OpenAPI ([guide](https://quarkus.io/guides/openapi-swaggerui)): Document your REST APIs with OpenAPI - comes with Swagger UI
+- REST Jackson ([guide](https://quarkus.io/guides/rest#json-serialisation)): Jackson serialization support for Quarkus REST. This extension is not compatible with the quarkus-resteasy extension, or any of the extensions that depend on it
+- SmallRye Health ([guide](https://quarkus.io/guides/smallrye-health)): Monitor service health
 - JDBC Driver - PostgreSQL ([guide](https://quarkus.io/guides/datasource)): Connect to the PostgreSQL database via JDBC
-- Building a Native Executable ([guide](https://quarkus.io/guides/building-native-image)): Creating a Linux executable without GraalVM installed
 
 ## Provided Code
 
-### RESTEasy Reactive
+### REST Data with Panache
 
-Easily start your Reactive RESTful Web Services
+Generating Jakarta REST resources with Panache
+
+[Related guide section...](https://quarkus.io/guides/rest-data-panache)
+
+
+### REST
+
+Easily start your REST Web Services
 
 [Related guide section...](https://quarkus.io/guides/getting-started-reactive#reactive-jax-rs-resources)
+
+### SmallRye Health
+
+Monitor your application's health using SmallRye Health
+
+[Related guide section...](https://quarkus.io/guides/smallrye-health)

--- a/pom.xml
+++ b/pom.xml
@@ -6,19 +6,19 @@
   <artifactId>library-shop</artifactId>
   <version>1.0.0</version>
   <properties>
-    <checkstyle.version>3.3.1</checkstyle.version>
-    <compiler-plugin.version>3.11.0</compiler-plugin.version>
-    <eclipse.jkube.version>1.15.0</eclipse.jkube.version>
+    <checkstyle.version>3.6.0</checkstyle.version>
+    <compiler-plugin.version>3.13.0</compiler-plugin.version>
+    <eclipse.jkube.version>1.17.0</eclipse.jkube.version>
     <jkube.build.switchToDeployment>true</jkube.build.switchToDeployment>
     <jkube.openshift.imageChangeTriggers>false</jkube.openshift.imageChangeTriggers>
-    <maven.compiler.release>17</maven.compiler.release>
+    <maven.compiler.release>21</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.6.0</quarkus.platform.version>
+    <quarkus.platform.version>3.17.2</quarkus.platform.version>
     <skipITs>true</skipITs>
-    <surefire-plugin.version>3.1.2</surefire-plugin.version>
+    <surefire-plugin.version>3.5.0</surefire-plugin.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -38,7 +38,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-resteasy-reactive-jackson</artifactId>
+      <artifactId>quarkus-rest-jackson</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
@@ -50,7 +50,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-resteasy-reactive</artifactId>
+      <artifactId>quarkus-rest</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
@@ -84,13 +84,6 @@
             </goals>
           </execution>
         </executions>
-        <dependencies>
-          <dependency>
-            <groupId>com.puppycrawl.tools</groupId>
-            <artifactId>checkstyle</artifactId>
-            <version>10.12.5</version>
-          </dependency>
-        </dependencies>
         <configuration>
           <configLocation>checkstyle.xml</configLocation>
           <includeTestSourceDirectory>false</includeTestSourceDirectory>
@@ -199,7 +192,8 @@
       </activation>
       <properties>
         <skipITs>false</skipITs>
-        <quarkus.package.type>native</quarkus.package.type>
+				<quarkus.native.enabled>true</quarkus.native.enabled>
+				<quarkus.package.jar.enabled>false</quarkus.package.jar.enabled>
       </properties>
     </profile>
     <profile>
@@ -214,7 +208,7 @@
       <properties>
         <skipTests>true</skipTests>
         <quarkus.container-image.build>true</quarkus.container-image.build>
-        <quarkus.jib.base-jvm-image>registry.access.redhat.com/ubi9/openjdk-17-runtime:1.17-1</quarkus.jib.base-jvm-image>
+        <quarkus.jib.base-jvm-image>registry.access.redhat.com/ubi9/openjdk-21-runtime:1.21-1</quarkus.jib.base-jvm-image>
         <quarkus.container-image.group>rha</quarkus.container-image.group>
         <quarkus.container-image.name>${project.artifactId}-jib</quarkus.container-image.name>
       </properties>

--- a/src/main/docker/Containerfile.jvm
+++ b/src/main/docker/Containerfile.jvm
@@ -77,7 +77,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-17-runtime:1.17-1
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.21-1
 
 ENV LANGUAGE='en_US:en'
 

--- a/src/main/docker/Containerfile.native
+++ b/src/main/docker/Containerfile.native
@@ -14,7 +14,7 @@
 # podman run -i --rm -p 8080:8080 rhacademy/library-shop-native
 #
 ###
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1029
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5-1731593028
 
 WORKDIR /work/
 RUN chown 1001 /work \

--- a/src/main/resources/META-INF/resources/index.html
+++ b/src/main/resources/META-INF/resources/index.html
@@ -238,7 +238,7 @@
                                 <li>GroupId: <code>org.acme</code></li>
                                 <li>ArtifactId: <code>library-shop</code></li>
                                 <li>Version: <code>1.0.0</code></li>
-                                <li>Quarkus Version: <code>3.6.0</code></li>
+                                <li>Quarkus Version: <code>3.17.2</code></li>
                             </ul>
                         </div>
                     </div>


### PR DESCRIPTION
Upgrade quarkus version and project dependencies

- Upgrade quarkus to latest version at the moment (3.17.2)
- Upgrade java dependencies and maven plugins to the latest available
- Upgrade container image to the latest reference