### PR TITLE
fix: disable well-known labels to match selector

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,7 @@
     <eclipse.jkube.version>1.17.0</eclipse.jkube.version>
     <jkube.build.switchToDeployment>true</jkube.build.switchToDeployment>
     <jkube.openshift.imageChangeTriggers>false</jkube.openshift.imageChangeTriggers>
+    <jkube.kubernetes.well-known-labels>false</jkube.kubernetes.well-known-labels>
     <maven.compiler.release>21</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>


### PR DESCRIPTION

- Fix conflict between well-known labels generated to the selector 
  and the labels in the deployment

@manusa