### PR TITLE
fix: fine-tunning application container

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -153,7 +153,7 @@
         <configuration>
           <resources>
             <labels>
-              <deployment>
+              <all>
                 <property>
                   <name>app.kubernetes.io/part-of</name>
                   <value>rhacademy</value>
@@ -162,6 +162,8 @@
                   <name>app.kubernetes.io/component</name>
                   <value>backend</value>
                 </property>
+              </all>
+              <deployment>
                 <property>
                   <name>app.openshift.io/runtime</name>
                   <value>quarkus</value>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -11,3 +11,8 @@ quarkus.devservices.enabled=true
 %prod.quarkus.datasource.jdbc.url=jdbc:postgresql://${DATABASE_HOST:localhost}:${DATABASE_PORT:5432}/${DATABASE_NAME:quarkus}
 
 %dev.quarkus.hibernate-orm.sql-load-script=import.sql
+
+
+# reproduceability of the jib image
+# https://github.com/GoogleContainerTools/jib/blob/master/docs/faq.md#why-is-my-image-created-48-years-ago
+quarkus.jib.use-current-timestamp=false


### PR DESCRIPTION
- define reproducibility for the jib image
- workaround for well-known labels in deployment

```
podman inspect rha/library-shop-jib:1.0.0 
[
  {
    "Id": "71d42082a086425b12416ae17ccf156bb520dc05bf281a82c0af8c57410f2fcd",
    "Digest": "sha256:49773ea07317a46f0f1d2c98bc40b8d8d7c819e75213ef28ec3f3af2c79f3da0",
...
    "Created": "1970-01-01T00:00:00Z",
```


@manusa